### PR TITLE
Fixes IE8, typeof addScript is 'object' not 'function'.

### DIFF
--- a/addScript.js
+++ b/addScript.js
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra
 */
 module.exports = function(src) {
-	if (typeof execScript === "function")
+	if (execScript)
 		execScript(src);
 	else
 		eval.call(null, src);


### PR DESCRIPTION
This is an alternative fix for #10. As @valscion pointed out #14 would have broken #5 again.