### PR TITLE
Update README with -loader suffix to support Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ``` javascript
-require("script!./file.js");
+require("script-loader!./file.js");
 // => execute file.js once in global context
 ```
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra